### PR TITLE
fix: update SRI hashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,4 @@ This repository hosts a purely client-side PDF compression tool accessible via `
 
 ## Working Memory Log
 - 2024-11-19: Created AGENTS.md to introduce working memory guidelines.
+- 2025-08-17: Updated SRI hashes for pdf.js and pdf-lib to resolve loading errors; no tests available.

--- a/index.html
+++ b/index.html
@@ -207,14 +207,14 @@
 
   <!-- Libraries: lightweight, client-only. No frameworks. -->
   <!-- pdf.js for reading and rasterizing pages -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" integrity="sha512-S8bJ3Kgl7p9HygGQ2mG4M8kP9qH1Vb3x6QA1s1vUq5oTtEozz0tq3m1W7oHy6n+XN1Qq1p9gL2+Z9M3nqh6Pdw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" integrity="sha512-q+4liFwdPC/bNdhUpZx6aXDx/h77yEQtn4I1slHydcbZK34nLaR3cAeYSJshoxIOq3mjEf7xJE8YWIUHMn+oCQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script>
     try {
       pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js";
     } catch (e) { console.warn(e); }
   </script>
   <!-- pdf-lib for writing a new compressed PDF -->
-  <script src="https://cdn.jsdelivr.net/npm/pdf-lib@1.17.1/dist/pdf-lib.min.js" integrity="sha384-ZB+QxM7Qd6dKnhy2yg1o3Q23IVYbQXvA0cQyR8MZkVd+5LkZ2BDseP2yWJ3L5y3C" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdn.jsdelivr.net/npm/pdf-lib@1.17.1/dist/pdf-lib.min.js" integrity="sha384-weMABwrltA6jWR8DDe9Jp5blk+tZQh7ugpCsF3JwSA53WZM9/14PjS5LAJNHNjAI" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
   <script>
     let file = null;


### PR DESCRIPTION
## Summary
- update pdf.js and pdf-lib script tags with correct integrity hashes to allow libraries to load
- note SRI fix in AGENTS log

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a1fdd862688327bd8cafcf184ee735