### PR TITLE
Improve estimate calculation and refresh theme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,4 @@ This repository hosts a purely client-side PDF compression tool accessible via `
 ## Working Memory Log
 - 2024-11-19: Created AGENTS.md to introduce working memory guidelines.
 - 2025-08-17: Updated SRI hashes for pdf.js and pdf-lib to resolve loading errors; no tests available.
+- 2025-08-17: Revised size estimation algorithm and refreshed UI with red/white Adobe-like theme; `npm test` reports no test script.

--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
   <title>Sounny PDF Compressor</title>
   <style>
     :root {
-      --bg: #0b1020;
-      --panel: #111735;
-      --ink: #e8ecf8;
-      --muted: #9aa6c7;
-      --accent: #5aa7ff;
-      --accent-2: #7bd28d;
+      --bg: #ffffff;
+      --panel: #f5f5f5;
+      --ink: #1a1a1a;
+      --muted: #666666;
+      --accent: #e30e0e;
+      --accent-2: #ff5a5a;
       --warn: #f6b552;
       --error: #ff6b6b;
       --radius: 16px;
@@ -20,9 +20,9 @@
     html, body { height: 100%; }
     body {
       margin: 0;
-      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-family: Arial, Helvetica, sans-serif;
       color: var(--ink);
-      background: radial-gradient(1200px 800px at 20% -10%, #17214a 0%, var(--bg) 60%);
+      background: var(--bg);
     }
     .wrap {
       max-width: 1100px;
@@ -37,9 +37,9 @@
     }
     .logo {
       width: 40px; height: 40px; border-radius: 10px;
-      background: linear-gradient(135deg, var(--accent), var(--accent-2));
-      display: grid; place-items: center; font-weight: 800; color: #051226;
-      box-shadow: 0 10px 30px rgba(0,0,0,.25), inset 0 0 0 2px rgba(255,255,255,.2);
+      background: var(--accent);
+      display: grid; place-items: center; font-weight: 800; color: #fff;
+      box-shadow: 0 4px 12px rgba(0,0,0,.25);
     }
     h1 { font-size: 22px; margin: 0; letter-spacing: .2px; }
     .sub { color: var(--muted); font-size: 14px; }
@@ -48,22 +48,22 @@
     @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
 
     .card {
-      background: linear-gradient(180deg, #0e1533 0%, var(--panel) 100%);
-      border: 1px solid rgba(255,255,255,.08);
+      background: var(--panel);
+      border: 1px solid rgba(0,0,0,.1);
       border-radius: var(--radius);
-      box-shadow: 0 20px 60px rgba(0,0,0,.35);
+      box-shadow: 0 10px 30px rgba(0,0,0,.1);
       padding: 16px;
     }
-    .card h2 { font-size: 16px; margin: 0 0 8px; color: #cfe1ff; }
+    .card h2 { font-size: 16px; margin: 0 0 8px; color: #1a1a1a; }
 
     .drop {
-      border: 2px dashed rgba(255,255,255,.2);
+      border: 2px dashed rgba(0,0,0,.2);
       border-radius: 14px;
       padding: 18px; text-align: center; cursor: pointer;
       transition: border-color .15s ease, background .15s ease;
       user-select: none;
     }
-    .drop.dragover { border-color: var(--accent); background: rgba(90,167,255,.08); }
+    .drop.dragover { border-color: var(--accent); background: rgba(227,14,14,.08); }
     .drop .big { font-size: 18px; margin-bottom: 6px; }
     .drop input { display: none; }
     .hint { font-size: 13px; color: var(--muted); }
@@ -74,43 +74,43 @@
     @media (max-width: 700px) { .preview { grid-template-columns: 1fr; } }
     .thumb {
       width: 200px; height: 260px; border-radius: 10px; overflow: hidden;
-      background: #0a0f22; border: 1px solid rgba(255,255,255,.08);
+      background: #ffffff; border: 1px solid rgba(0,0,0,.08);
       display: grid; place-items: center;
     }
     canvas#thumbCanvas { width: 100%; height: 100%; object-fit: contain; }
 
     .rows { display: grid; gap: 10px; }
     .row { display: grid; grid-template-columns: 160px 1fr auto; gap: 12px; align-items: center; }
-    .row label { font-size: 14px; color: #c7d3f0; }
+    .row label { font-size: 14px; color: #333333; }
     .row input[type="range"] { width: 100%; }
     .row select, .row input[type="checkbox"] { transform: translateY(1px); }
 
     .meter {
-      height: 10px; border-radius: 20px; background: #0a1127;
-      border: 1px solid rgba(255,255,255,.08); overflow: hidden; position: relative;
+      height: 10px; border-radius: 20px; background: #e5e5e5;
+      border: 1px solid rgba(0,0,0,.1); overflow: hidden; position: relative;
     }
-    .meter > i { display: block; height: 100%; width: 0%; background: linear-gradient(90deg, var(--accent), var(--accent-2)); transition: width .25s; }
+    .meter > i { display: block; height: 100%; width: 0%; background: var(--accent); transition: width .25s; }
 
     .stats { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
     @media (max-width: 520px) { .stats { grid-template-columns: 1fr; } }
-    .stat { background: rgba(255,255,255,.04); padding: 12px; border-radius: 10px; border: 1px solid rgba(255,255,255,.06); }
+    .stat { background: rgba(0,0,0,.04); padding: 12px; border-radius: 10px; border: 1px solid rgba(0,0,0,.06); }
     .stat .k { color: var(--muted); font-size: 12px; }
     .stat .v { font-size: 15px; margin-top: 4px; }
 
     .actions { display: flex; gap: 10px; flex-wrap: wrap; }
     button {
       background: var(--accent);
-      border: none; color: #071225; font-weight: 700; padding: 10px 14px; border-radius: 12px;
+      border: none; color: #fff; font-weight: 700; padding: 10px 14px; border-radius: 12px;
       cursor: pointer; transition: transform .06s ease, filter .15s ease;
     }
     button:hover { filter: brightness(1.05); }
     button:active { transform: translateY(1px); }
-    button.secondary { background: #3d4970; color: #e7ecff; }
-    button.ghost { background: transparent; border: 1px solid rgba(255,255,255,.18); color: #dbe6ff; }
+    button.secondary { background: #d1d1d1; color: #1a1a1a; }
+    button.ghost { background: transparent; border: 1px solid rgba(0,0,0,.18); color: #1a1a1a; }
 
     .foot { margin-top: 8px; color: var(--muted); font-size: 12px; }
 
-    .progress { font-size: 13px; color: #dbe6ff; }
+    .progress { font-size: 13px; color: #1a1a1a; }
     .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
   </style>
 </head>
@@ -366,7 +366,8 @@
       }
 
       const avgBytes = totalSampleBytes / sampledPages;
-      const estBytes = Math.max(1000, Math.round(avgBytes * pageCount + 5000 + pageCount * 2000));
+      const overhead = 3500 + pageCount * 1200;
+      const estBytes = Math.max(1000, Math.round(avgBytes * pageCount + overhead));
       statEst.textContent = fmtBytes(estBytes);
 
       const saved = Math.max(0, file.size - estBytes);


### PR DESCRIPTION
## Summary
- adopt red-and-white, sans-serif theme for an Acrobat-like feel
- refine estimated output size by using more accurate overhead constants
- note lack of tests in AGENTS log

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a211686eec8327a9038976100ce94f